### PR TITLE
Podman Support and Shellcheck

### DIFF
--- a/bin/latex-docker
+++ b/bin/latex-docker
@@ -7,4 +7,4 @@ popd >/dev/null
 PARENT_NAME="$(basename "$PARENT_DIR")"
 parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
 
-docker run --rm -i --user="$(id -u):$(id -g)" -a stdin -a stdout -v "$PWD":/data "$parent_name/latex:latest" "$@"
+${CONTAINER_ENGINE:-podman} run --rm -i --user="$(id -u):$(id -g)" -a stdin -a stdout -v "$PWD":/data "$parent_name/latex:latest" "$@"

--- a/bin/latex-docker
+++ b/bin/latex-docker
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 cd ..
 PARENT_DIR="$PWD"
 popd >/dev/null
 PARENT_NAME="$(basename "$PARENT_DIR")"
-parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
+parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 ${CONTAINER_ENGINE:-podman} run --rm -i --user="$(id -u):$(id -g)" -a stdin -a stdout -v "$PWD":/data "$parent_name/latex:latest" "$@"

--- a/bin/latex-docker
+++ b/bin/latex-docker
@@ -7,4 +7,4 @@ popd >/dev/null
 PARENT_NAME="$(basename "$PARENT_DIR")"
 parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
-${CONTAINER_ENGINE:-podman} run --rm -i --user="$(id -u):$(id -g)" -a stdin -a stdout -v "$PWD":/data "$parent_name/latex:latest" "$@"
+${CONTAINER_ENGINE:-docker} run --rm -i --user="$(id -u):$(id -g)" -a stdin -a stdout -v "$PWD":/data "$parent_name/latex:latest" "$@"

--- a/bin/latex-docker-command
+++ b/bin/latex-docker-command
@@ -1,7 +1,7 @@
 #!/bin/bash
 this="${BASH_SOURCE[0]}"
 cmd="$(basename "$this")"
-pushd $(dirname "$this") >/dev/null
+pushd "$(dirname "$this")" >/dev/null
 this_dir="$PWD"
 popd >/dev/null
 "$this_dir/latex-docker" "$cmd" "$@"

--- a/bin/latex-docker-context
+++ b/bin/latex-docker-context
@@ -1,6 +1,8 @@
+# shellcheck shell=bash
+
 # find directory of this sourced context
 
-pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 latex_docker_bin="$PWD"
 popd >/dev/null
 
@@ -14,4 +16,4 @@ PATH="$latex_docker_bin${PATH%:}"
 # invalidate cache
 hash -r
 
-
+# vim: ft=sh:

--- a/bin/latex-docker-rebuild
+++ b/bin/latex-docker-rebuild
@@ -20,7 +20,7 @@ THIS_DIR="$(get_script_dir)"
 cd $THIS_DIR
 cd ..
 
-curl -L https://github.com/wmacevoy/latex-docker/tarball/master | wctar -zxv --strip=1 '*/bin' '*/dockers'
+curl -L https://github.com/Ma124/latex-docker/tarball/master | wctar -zxv --strip=1 '*/bin' '*/dockers'
 bin/latex-docker-setup
 if git rev-parse --is-inside-work-tree > /dev/null 2>&1
 then

--- a/bin/latex-docker-rebuild
+++ b/bin/latex-docker-rebuild
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_script_dir () {
-    pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+    pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
     pwd
     popd >/dev/null
 }
@@ -17,8 +17,8 @@ wctar () {
 
 THIS_DIR="$(get_script_dir)"
 
-cd $THIS_DIR
-cd ..
+cd "$THIS_DIR" || exit 254
+cd .. || exit 254
 
 curl -L https://github.com/Ma124/latex-docker/tarball/master | wctar -zxv --strip=1 '*/bin' '*/dockers'
 bin/latex-docker-setup

--- a/bin/latex-docker-rebuild
+++ b/bin/latex-docker-rebuild
@@ -20,7 +20,7 @@ THIS_DIR="$(get_script_dir)"
 cd "$THIS_DIR" || exit 254
 cd .. || exit 254
 
-curl -L https://github.com/Ma124/latex-docker/tarball/master | wctar -zxv --strip=1 '*/bin' '*/dockers'
+curl -L https://github.com/wmacevoy/latex-docker/tarball/master | wctar -zxv --strip=1 '*/bin' '*/dockers'
 bin/latex-docker-setup
 if git rev-parse --is-inside-work-tree > /dev/null 2>&1
 then

--- a/bin/latex-docker-setup
+++ b/bin/latex-docker-setup
@@ -14,10 +14,10 @@ base_name="$(echo "$BASE_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 "$THIS_DIR"/latex-docker-setup-base
 
-(cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-podman} build -t "$base_name/latex:latest" latex)
+(cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-docker} build -t "$base_name/latex:latest" latex)
 
 # shellcheck disable=SC2016
-CMDS="$(${CONTAINER_ENGINE:-podman} run --rm -a stdin -a stdout "$base_name/latex:latest" /bin/sh -c 'ls `echo $PATH  | cut -d: -f1`')"
+CMDS="$(${CONTAINER_ENGINE:-docker} run --rm -a stdin -a stdout "$base_name/latex:latest" /bin/sh -c 'ls `echo $PATH  | cut -d: -f1`')"
 
 cd "$BASE_DIR/bin" || exit 254
 if [ ! -f .gitignore ] ; then touch .gitignore ; fi

--- a/bin/latex-docker-setup
+++ b/bin/latex-docker-setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_script_dir () {
-    pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+    pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
     pwd
     popd >/dev/null
 }
@@ -9,29 +9,30 @@ get_script_dir () {
 THIS_DIR="$(get_script_dir)"
 BASE_DIR="$(dirname "$THIS_DIR")"
 BASE_NAME="$(basename "$BASE_DIR")"
-base_name="$(echo $BASE_NAME | tr ' [:upper:]' '_[:lower:]')"
+base_name="$(echo "$BASE_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 
 "$THIS_DIR"/latex-docker-setup-base
 
 (cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-podman} build -t "$base_name/latex:latest" latex)
 
+# shellcheck disable=SC2016
 CMDS="$(${CONTAINER_ENGINE:-podman} run --rm -a stdin -a stdout "$base_name/latex:latest" /bin/sh -c 'ls `echo $PATH  | cut -d: -f1`')"
 
-cd "$BASE_DIR/bin"
+cd "$BASE_DIR/bin" || exit 254
 if [ ! -f .gitignore ] ; then touch .gitignore ; fi
 for cmd in $CMDS
 do
     /bin/rm -rf "$cmd"
     ln -s "latex-docker-command" "$cmd"
     chmod +x "$BASE_DIR/bin/$cmd"
-    if ! egrep -q "^$cmd$" .gitignore
+    if ! grep -Eq "^$cmd$" .gitignore
     then
         echo "$cmd" >> .gitignore
     fi
 done
 
+# shellcheck disable=2016
 echo 'Type ". bin/latex-docker-context" to add $BASE_DIR/bin to your PATH.'
 echo 'Type ". bin/latex-docker-uncontext" to remove it.'
-
 

--- a/bin/latex-docker-setup
+++ b/bin/latex-docker-setup
@@ -14,9 +14,9 @@ base_name="$(echo $BASE_NAME | tr ' [:upper:]' '_[:lower:]')"
 
 "$THIS_DIR"/latex-docker-setup-base
 
-(cd "$BASE_DIR/dockers" && docker build -t "$base_name/latex:latest" latex)
+(cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-podman} build -t "$base_name/latex:latest" latex)
 
-CMDS="$(docker run --rm -a stdin -a stdout "$base_name/latex:latest" /bin/sh -c 'ls `echo $PATH  | cut -d: -f1`')"
+CMDS="$(${CONTAINER_ENGINE:-podman} run --rm -a stdin -a stdout "$base_name/latex:latest" /bin/sh -c 'ls `echo $PATH  | cut -d: -f1`')"
 
 cd "$BASE_DIR/bin"
 if [ ! -f .gitignore ] ; then touch .gitignore ; fi

--- a/bin/latex-docker-setup-base
+++ b/bin/latex-docker-setup-base
@@ -25,7 +25,7 @@ if [ ! -f "$BASE_DIR/dockers/latex/Dockerfile" ] ; then
     echo "Edit this file before running $BASE_DIR/bin/latex-docker-setup if you want a custom setup."
     mkdir -p "$BASE_DIR/dockers/latex"
     cat >"$BASE_DIR/dockers/latex/Dockerfile" <<EOF
-FROM "$base_name/latex-base:latest"
+FROM $base_name/latex-base:latest
 #
 # I know "scheme-full" is tempting, but three hours later you may have wished you picked out the packages...
 #

--- a/bin/latex-docker-setup-base
+++ b/bin/latex-docker-setup-base
@@ -11,14 +11,14 @@ BASE_DIR="$(dirname "$THIS_DIR")"
 BASE_NAME="$(basename "$BASE_DIR")"
 base_name="$(echo "$BASE_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
-if ! which "${CONTAINER_ENGINE:-podman}" > /dev/null
+if ! which "${CONTAINER_ENGINE:-docker}" > /dev/null
 then
     # shellcheck disable=2016
     echo 'you must install docker (or podman and set $CONTAINER_ENGINE)...'
     exit 1
 fi
 
-(cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-podman} build -t "$base_name/latex-base:latest" latex-base)
+(cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-docker} build -t "$base_name/latex-base:latest" latex-base)
 
 if [ ! -f "$BASE_DIR/dockers/latex/Dockerfile" ] ; then
     echo "Creating a default (full texlive install) Dockerfile in $BASE_DIR/dockers/latex"

--- a/bin/latex-docker-setup-base
+++ b/bin/latex-docker-setup-base
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_script_dir () {
-    pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+    pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
     pwd
     popd >/dev/null
 }
@@ -9,10 +9,11 @@ get_script_dir () {
 THIS_DIR="$(get_script_dir)"
 BASE_DIR="$(dirname "$THIS_DIR")"
 BASE_NAME="$(basename "$BASE_DIR")"
-base_name="$(echo $BASE_NAME | tr ' [:upper:]' '_[:lower:]')"
+base_name="$(echo "$BASE_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
-if ! which ${CONTAINER_ENGINE:-podman} > /dev/null
+if ! which "${CONTAINER_ENGINE:-podman}" > /dev/null
 then
+    # shellcheck disable=2016
     echo 'you must install docker (or podman and set $CONTAINER_ENGINE)...'
     exit 1
 fi

--- a/bin/latex-docker-setup-base
+++ b/bin/latex-docker-setup-base
@@ -11,13 +11,13 @@ BASE_DIR="$(dirname "$THIS_DIR")"
 BASE_NAME="$(basename "$BASE_DIR")"
 base_name="$(echo $BASE_NAME | tr ' [:upper:]' '_[:lower:]')"
 
-if ! which docker > /dev/null
+if ! which ${CONTAINER_ENGINE:-podman} > /dev/null
 then
-    echo "you must install docker..."
+    echo 'you must install docker (or podman and set $CONTAINER_ENGINE)...'
     exit 1
 fi
 
-(cd "$BASE_DIR/dockers" && docker build -t "$base_name/latex-base:latest" latex-base)
+(cd "$BASE_DIR/dockers" && ${CONTAINER_ENGINE:-podman} build -t "$base_name/latex-base:latest" latex-base)
 
 if [ ! -f "$BASE_DIR/dockers/latex/Dockerfile" ] ; then
     echo "Creating a default (full texlive install) Dockerfile in $BASE_DIR/dockers/latex"

--- a/bin/latex-docker-uncontext
+++ b/bin/latex-docker-uncontext
@@ -1,6 +1,8 @@
+# shellcheck shell=bash
+
 # find directory of this sourced context
 
-pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 latex_docker_bin="$PWD"
 popd >/dev/null
 
@@ -15,4 +17,4 @@ PATH="${PATH#:}"
 # invalidate cache
 hash -r
 
-
+# vim: ft=sh:

--- a/bin/latexdockercmd.sh
+++ b/bin/latexdockercmd.sh
@@ -9,4 +9,4 @@ parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
 
 IMAGE="$parent_name/latex:latest"
 
-exec docker run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"
+exec ${CONTAINER_ENGINE:-podman} run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"

--- a/bin/latexdockercmd.sh
+++ b/bin/latexdockercmd.sh
@@ -9,4 +9,4 @@ parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 IMAGE="$parent_name/latex:latest"
 
-exec "${CONTAINER_ENGINE:-podman}" run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"
+exec "${CONTAINER_ENGINE:-docker}" run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"

--- a/bin/latexdockercmd.sh
+++ b/bin/latexdockercmd.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 cd ..
 PARENT_DIR="$PWD"
 popd >/dev/null
 PARENT_NAME="$(basename "$PARENT_DIR")"
-parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
+parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 IMAGE="$parent_name/latex:latest"
 
-exec ${CONTAINER_ENGINE:-podman} run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"
+exec "${CONTAINER_ENGINE:-podman}" run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":/data "$IMAGE" "$@"

--- a/bin/latexdockerdaemon.sh
+++ b/bin/latexdockerdaemon.sh
@@ -10,4 +10,4 @@ parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 IMAGE="$parent_name/latex:latest"
 NAME="$(echo "$IMAGE:daemon" | tr '/:' '--')"
 
-exec "${CONTAINER_ENGINE:-podman}" run -d --rm --name "$NAME" -i --user="$(id -u):$(id -g)" --net=none -t -v "$PWD:/data" "$IMAGE" /bin/sh -c "sleep infinity"
+exec "${CONTAINER_ENGINE:-docker}" run -d --rm --name "$NAME" -i --user="$(id -u):$(id -g)" --net=none -t -v "$PWD:/data" "$IMAGE" /bin/sh -c "sleep infinity"

--- a/bin/latexdockerdaemon.sh
+++ b/bin/latexdockerdaemon.sh
@@ -10,4 +10,4 @@ parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
 IMAGE="$parent_name/latex:latest"
 NAME="$(echo $IMAGE:daemon | tr '/:' '--')"
 
-exec docker run -d --rm --name "$NAME" -i --user="$(id -u):$(id -g)" --net=none -t -v $PWD:/data "$IMAGE" /bin/sh -c "sleep infinity"
+exec ${CONTAINER_ENGINE:-podman} run -d --rm --name "$NAME" -i --user="$(id -u):$(id -g)" --net=none -t -v $PWD:/data "$IMAGE" /bin/sh -c "sleep infinity"

--- a/bin/latexdockerdaemon.sh
+++ b/bin/latexdockerdaemon.sh
@@ -1,13 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
-pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 cd ..
 PARENT_DIR="$PWD"
 popd >/dev/null
 PARENT_NAME="$(basename "$PARENT_DIR")"
-parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
+parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 IMAGE="$parent_name/latex:latest"
-NAME="$(echo $IMAGE:daemon | tr '/:' '--')"
+NAME="$(echo "$IMAGE:daemon" | tr '/:' '--')"
 
-exec ${CONTAINER_ENGINE:-podman} run -d --rm --name "$NAME" -i --user="$(id -u):$(id -g)" --net=none -t -v $PWD:/data "$IMAGE" /bin/sh -c "sleep infinity"
+exec "${CONTAINER_ENGINE:-podman}" run -d --rm --name "$NAME" -i --user="$(id -u):$(id -g)" --net=none -t -v "$PWD:/data" "$IMAGE" /bin/sh -c "sleep infinity"

--- a/bin/latexdockerdaemoncmd.sh
+++ b/bin/latexdockerdaemoncmd.sh
@@ -10,4 +10,4 @@ parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 IMAGE="$parent_name/latex:latest"
 NAME="$(echo "$IMAGE:daemon" | tr '/:' '--')"
 
-exec "${CONTAINER_ENGINE:-podman}" exec -it "$NAME" "$@"
+exec "${CONTAINER_ENGINE:-docker}" exec -it "$NAME" "$@"

--- a/bin/latexdockerdaemoncmd.sh
+++ b/bin/latexdockerdaemoncmd.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-pushd $(dirname "${BASH_SOURCE[0]}") >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 cd ..
 PARENT_DIR="$PWD"
 popd >/dev/null
 PARENT_NAME="$(basename "$PARENT_DIR")"
-parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
+parent_name="$(echo "$PARENT_NAME" | tr ' [:upper:]' '_[:lower:]')"
 
 IMAGE="$parent_name/latex:latest"
-NAME="$(echo $IMAGE:daemon | tr '/:' '--')"
+NAME="$(echo "$IMAGE:daemon" | tr '/:' '--')"
 
-exec ${CONTAINER_ENGINE:-podman} exec -it "$NAME" "$@"
+exec "${CONTAINER_ENGINE:-podman}" exec -it "$NAME" "$@"

--- a/bin/latexdockerdaemoncmd.sh
+++ b/bin/latexdockerdaemoncmd.sh
@@ -10,4 +10,4 @@ parent_name="$(echo $PARENT_NAME | tr ' [:upper:]' '_[:lower:]')"
 IMAGE="$parent_name/latex:latest"
 NAME="$(echo $IMAGE:daemon | tr '/:' '--')"
 
-exec docker exec -it "$NAME" "$@"
+exec ${CONTAINER_ENGINE:-podman} exec -it "$NAME" "$@"


### PR DESCRIPTION
I really like your project but I'm using [Podman](https://podman.io/), a drop-in replacement for docker. I changed the scripts in [`./bin/`](./bin/) to still use docker by default but enable podman support by setting `$CONTAINER_ENGINE=podman`.

Secondly I ran [Shellcheck](https://www.shellcheck.net/), a linter for shell scripts, and fixed all warnings which were mostly just [`SC2086`](https://github.com/koalaman/shellcheck/wiki/SC2086).

So all in all this does not change anything that is already in production but just adds the option to use Podman.